### PR TITLE
Add support for no HA and config page on display

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,10 +1,6 @@
 name: CI
 
-on:
-  pull_request:
-    paths:
-      - '*.yaml'
-      - '.github/workflows/ci.yml'
+on: pull_request
 
 jobs:
   ci:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,14 +17,13 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4.1.7
-      - name: ESPHome ${{ matrix.esphome-version }}
+      - name: Build firmware with ESPHome ${{ matrix.esphome-version }}
         uses: esphome/build-action@v6.0.0
+        id: esphome-build
         with:
           yaml-file: ${{ matrix.file }}
           version: ${{ matrix.esphome-version }}
-            - name: Upload artifact
       - name: upload build
         uses: actions/upload-artifact@v4.6.2
         with:
-          name: ${{ steps.esphome-build.outputs.name }}
-          path: output
+          path: ${{ steps.esphome-build.outputs.name }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,13 @@ jobs:
         with:
           yaml-file: ${{ matrix.file }}
           version: ${{ matrix.esphome-version }}
-      - name: upload build
+      - name: upload factory build
         uses: actions/upload-artifact@v4.6.2
         with:
-          path: ${{ steps.esphome-build.outputs.name }}
+          name: Factory build
+          path: ${{ steps.esphome-build.outputs.name }}/${{ steps.esphome-build.outputs.name }}.factory.bin
+      - name: upload OTA build
+        uses: actions/upload-artifact@v4.6.2
+        with:
+          name: OTA build
+          path: ${{ steps.esphome-build.outputs.name }}/${{ steps.esphome-build.outputs.name }}.ota.bin

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,13 +23,7 @@ jobs:
         with:
           yaml-file: ${{ matrix.file }}
           version: ${{ matrix.esphome-version }}
-      - name: upload factory build
+      - name: upload build
         uses: actions/upload-artifact@v4.6.2
         with:
-          name: Factory build
-          path: ${{ steps.esphome-build.outputs.name }}/${{ steps.esphome-build.outputs.name }}.factory.bin
-      - name: upload OTA build
-        uses: actions/upload-artifact@v4.6.2
-        with:
-          name: OTA build
-          path: ${{ steps.esphome-build.outputs.name }}/${{ steps.esphome-build.outputs.name }}.ota.bin
+          path: ${{ steps.esphome-build.outputs.name }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,6 @@ jobs:
       max-parallel: 3
       matrix:
         file:
-          - TFT_LCD/T-Display-Long/V1/Firmware/ESPHome/Halo-v1.yaml
           - TFT_LCD/T-Display-Long/V1/Firmware/ESPHome/Halo-v1-dev.yaml
         esphome-version:
           - stable
@@ -23,3 +22,9 @@ jobs:
         with:
           yaml-file: ${{ matrix.file }}
           version: ${{ matrix.esphome-version }}
+            - name: Upload artifact
+      - name: upload build
+        uses: actions/upload-artifact@v4.6.2
+        with:
+          name: ${{ steps.esphome-build.outputs.name }}
+          path: output

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  pull_request:
+    paths:
+      - '*.yaml'
+      - '.github/workflows/ci.yml'
+
+jobs:
+  ci:
+    name: Building ${{ matrix.file }} / ${{ matrix.esphome-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        file:
+          - TFT_LCD/T-Display-Long/V1/Firmware/ESPHome/Halo-v1.yaml
+          - TFT_LCD/T-Display-Long/V1/Firmware/ESPHome/Halo-v1-dev.yaml
+        esphome-version:
+          - stable
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4.1.7
+      - name: ESPHome ${{ matrix.esphome-version }}
+        uses: esphome/build-action@v6.0.0
+        with:
+          yaml-file: ${{ matrix.file }}
+          version: ${{ matrix.esphome-version }}

--- a/TFT_LCD/T-Display-Long/V1/Firmware/ESPHome/Halo-v1-Core.yaml
+++ b/TFT_LCD/T-Display-Long/V1/Firmware/ESPHome/Halo-v1-Core.yaml
@@ -1559,7 +1559,7 @@ lvgl:
             long_mode: SCROLL
             x: -2
             y: -193
-            text: ""
+            text: "None"
         - line:
             points:
               - 0, 147
@@ -1584,7 +1584,7 @@ lvgl:
             long_mode: WRAP
             x: -2
             y: -152
-            text: ""
+            text: "No"
         - line:
             points:
               - 0, 188

--- a/TFT_LCD/T-Display-Long/V1/Firmware/ESPHome/Halo-v1-Core.yaml
+++ b/TFT_LCD/T-Display-Long/V1/Firmware/ESPHome/Halo-v1-Core.yaml
@@ -18,7 +18,7 @@ esp32_improv:
   authorizer: none
 
 external_components:
-  - source: github://yashmulgaonkar/esphome-components
+  - source: github://yashmulgaonkar/esphome-components@main
     components: [axs15231, sy6970]
 
 spi:

--- a/TFT_LCD/T-Display-Long/V1/Firmware/ESPHome/Halo-v1-Core.yaml
+++ b/TFT_LCD/T-Display-Long/V1/Firmware/ESPHome/Halo-v1-Core.yaml
@@ -131,7 +131,7 @@ api:
   on_client_connected:
       - delay: 1s
       - light.turn_off: rgb_light
-      - lambda: 'id(cycleCounter) = 30;'    
+      - lambda: 'id(cycleCounter) = 30;'
   services:
     #Co2 Calibration Service
     - service: calibrate_co2_value
@@ -185,14 +185,6 @@ touchscreen:
       mirror_x: false
       mirror_y: false
       swap_xy: false
-    on_touch:
-      - lambda: |-
-            ESP_LOGI("cal", "x=%d, y=%d, x_raw=%d, y_raw=%0d",
-            touch.x,
-            touch.y,
-            touch.x_raw,
-            touch.y_raw
-            );
 
 web_server:
   port: 80
@@ -300,7 +292,16 @@ number:
 binary_sensor:
   - platform: status
     name: Online
-    id: ink_ha_connected    
+    id: ink_ha_connected
+    on_state:
+      then:
+        - lvgl.label.update:
+            id: config_ha_connected_value
+            text: !lambda |-
+              if(x)
+                return "Yes";
+              else
+                return "No";
 
 sensor:
   - platform: uptime
@@ -916,6 +917,23 @@ text_sensor:
         return std::string("Very abnormal");} 
       else {
         return std::string("Extremely abnormal");}    
+  - platform: wifi_info
+    ip_address:
+      name: ESP IP Address
+      address_0:
+        name: ESP IP Address
+        on_value:
+          then:
+            - lvgl.label.update:
+                id: config_ip_value
+                text: !lambda "return x;"
+    ssid:
+      name: ESP Connected SSID
+      on_value:
+        then:
+          - lvgl.label.update:
+              id: config_ssid_value
+              text: !lambda "return x;"
 
 light:
   - platform: esp32_rmt_led_strip
@@ -948,33 +966,43 @@ lvgl:
   touchscreens:
     - lily_touch
   buffer_size: 100%
+  top_layer:
+    widgets:
+      - image:
+          id: ym_image
+          src: ym_logo
+          align: CENTER
+          x: 80
+          y: -309
+      - label:
+          id: timeVal
+          align: LEFT_MID
+          text_font: montserrat_18
+          text_color: my_white
+          x: 2
+          y: -309
+          text: "00:00AM"
+      - label:
+          id: wifi_stat
+          align: CENTER
+          text_font: montserrat_18
+          text_color: my_gray
+          x: 42
+          y: -309
+          text: "\uF1EB"
   pages:            
     - id: main_page
       bg_color: my_black
       scrollbar_mode: "OFF"
+      on_swipe_left:
+        - lvgl.page.next:
+            animation: OUT_LEFT
+            time: 200ms
+      on_swipe_right:
+        - lvgl.page.previous:
+            animation: OUT_RIGHT
+            time: 200ms
       widgets:
-        - image:
-            id: ym_image          
-            src: ym_logo
-            align: CENTER
-            x: 80
-            y: -309
-        - label:
-            id: timeVal
-            align: LEFT_MID
-            text_font: montserrat_18
-            text_color: my_white
-            x: 2
-            y: -309
-            text: "00:00AM"
-        - label:
-            id: wifi_stat
-            align: CENTER
-            text_font: montserrat_18
-            text_color: my_gray
-            x: 42
-            y: -309
-            text: "\uF1EB"
 # AQI box
         - obj:
             id: aqi_widget
@@ -1473,3 +1501,90 @@ lvgl:
             x: -2
             y: 299
             text: "%"
+    - id: config_page
+      bg_color: my_black
+      scrollbar_mode: "OFF"
+      on_swipe_left:
+        - lvgl.page.next:
+            animation: OUT_LEFT
+            time: 200ms
+      on_swipe_right:
+        - lvgl.page.previous:
+            animation: OUT_RIGHT
+            time: 200ms
+      widgets:
+# IP address box
+        - label:
+            id: config_ip_label
+            align: LEFT_MID
+            text_font: montserrat_14
+            text_color: my_white
+            long_mode: WRAP
+            x: 2
+            y: -246
+            text: "IP:"
+        - label:
+            id: config_ip_value
+            align: RIGHT_MID
+            text_font: montserrat_22
+            text_color: my_white
+            long_mode: WRAP
+            x: -2
+            y: -234
+            text: "0.0.0.0"
+        - line:
+            points:
+              - 0, 106
+              - 180, 106
+            line_width: 1
+            line_color: 0x00dfff
+# SSID box
+        - label:
+            id: config_ssid_label
+            align: LEFT_MID
+            text_font: montserrat_14
+            text_color: my_white
+            long_mode: SCROLL
+            x: 2
+            y: -205
+            text: "SSID:"
+        - label:
+            id: config_ssid_value
+            align: RIGHT_MID
+            text_font: montserrat_22
+            text_color: my_white
+            long_mode: SCROLL
+            x: -2
+            y: -193
+            text: ""
+        - line:
+            points:
+              - 0, 147
+              - 180, 147
+            line_width: 1
+            line_color: 0x00dfff
+# HA Connected box
+        - label:
+            id: config_ha_connected_label
+            align: LEFT_MID
+            text_font: montserrat_14
+            text_color: my_white
+            long_mode: WRAP
+            x: 2
+            y: -164
+            text: "HA Connected:"
+        - label:
+            id: config_ha_connected_value
+            align: RIGHT_MID
+            text_font: montserrat_22
+            text_color: my_white
+            long_mode: WRAP
+            x: -2
+            y: -152
+            text: ""
+        - line:
+            points:
+              - 0, 188
+              - 180, 188
+            line_width: 1
+            line_color: 0x00dfff

--- a/TFT_LCD/T-Display-Long/V1/Firmware/ESPHome/Halo-v1-Core.yaml
+++ b/TFT_LCD/T-Display-Long/V1/Firmware/ESPHome/Halo-v1-Core.yaml
@@ -18,7 +18,8 @@ esp32_improv:
   authorizer: none
 
 external_components:
-  - source: github://yashmulgaonkar/esphome-components@main
+  # Temp fix to compile with https://github.com/yashmulgaonkar/esphome-components/pull/1
+  - source: github://dkowis/esphome-components@main
     components: [axs15231, sy6970]
 
 spi:

--- a/TFT_LCD/T-Display-Long/V1/Firmware/ESPHome/Halo-v1-Core.yaml
+++ b/TFT_LCD/T-Display-Long/V1/Firmware/ESPHome/Halo-v1-Core.yaml
@@ -13,6 +13,8 @@ esp32:
   flash_size: 16MB
   framework:
     type: esp-idf
+    advanced:
+      enable_idf_experimental_features: true
 
 esp32_improv:
   authorizer: none

--- a/TFT_LCD/T-Display-Long/V1/Firmware/ESPHome/Halo-v1-dev.yaml
+++ b/TFT_LCD/T-Display-Long/V1/Firmware/ESPHome/Halo-v1-dev.yaml
@@ -1,12 +1,15 @@
 esphome:
   name: halo-v1
   friendly_name: Halo Air Quality Sensor
+  name_add_mac_suffix: true
   platformio_options:
     upload_speed: 921600
     build_unflags: -Werror=all
     board_build.flash_mode: dio
     board_build.f_flash: 80000000L
     board_build.f_cpu: 240000000L
+
+  min_version: 2025.2.0
 
   project:
     name: "yashmulgaonkar.Halo-v1"
@@ -18,6 +21,7 @@ dashboard_import:
 
 ota:
   - platform: esphome
+    id: ota_default
 
 wifi:
   # Disable power save more for compatibility with some Ubiquiti networks.
@@ -35,11 +39,15 @@ web_server:
 packages:
   core: !include Halo-v1-Core.yaml
 
-# Add local timezone for development since Docker container not set to local timezone
+# Add local timezone and use sntp instead of time from HA
 time:
-  - platform: homeassistant
+  - platform: sntp
     id: !extend ha_time
     timezone: "America/Chicago"
+
+# Disable reboot if HA connection times out
+api:
+  reboot_timeout: 0s
 
 # required to disable wifi power save mode
 esp32_improv: !remove

--- a/TFT_LCD/T-Display-Long/V1/Firmware/ESPHome/Halo-v1-dev.yaml
+++ b/TFT_LCD/T-Display-Long/V1/Firmware/ESPHome/Halo-v1-dev.yaml
@@ -5,7 +5,8 @@ esphome:
   platformio_options:
     upload_speed: 921600
     build_unflags: -Werror=all
-    board_build.flash_mode: dio
+    board_build.flash_mode: qio
+    board_build.prsam_type: opi
     board_build.f_flash: 80000000L
     board_build.f_cpu: 240000000L
 


### PR DESCRIPTION
In the dev config, this adds removes reboot time for HA connections and uses SNTP instead of the HA time connection.

Additionally, in the base config, this adds a new display page you can swipe to that shows the connection information for the Halo.